### PR TITLE
Add deprecation warning to apk-install

### DIFF
--- a/builder/scripts/apk-install
+++ b/builder/scripts/apk-install
@@ -1,3 +1,3 @@
 #!/bin/sh
-echo "!! apk-install is deprecated. recommended: apk add --update <packages> && rm -rf /var/cache/apk/*"
+echo "!! apk-install is deprecated. recommended: apk add --update <packages> && rm -rf /var/cache/apk/*" 1>&2
 apk add --update "$@" && rm -rf /var/cache/apk/*

--- a/builder/scripts/apk-install
+++ b/builder/scripts/apk-install
@@ -1,2 +1,3 @@
 #!/bin/sh
+echo "!! apk-install is deprecated. recommended: apk add --update <packages> && rm -rf /var/cache/apk/*"
 apk add --update "$@" && rm -rf /var/cache/apk/*

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,19 +30,6 @@ EXPOSE 8080
 CMD ["/env/bin/python", "main.py"]
 ```
 
-## Convenience Cleanup
-
-This image contains a small unofficial wrapper script that assists in the cleanup of the package index after installing packages. A great minimalist cleans up after ones self. Thus, the `apk-install` script was born. Here is another simple `Dockerfile` that installs the `nginx` package and removes package index data:
-
-```
-FROM gliderlabs/alpine:3.1
-
-RUN apk-install nginx
-
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
-```
-
 ## Virtual Packages
 
 Another great `apk add` feature for cleanup is the concept of virtual packages using the `--virtual` or `-t` switch. Packages added under this virtual name can then be removed as one group. An example use of this would be removing a group of build dependencies all at once:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,9 +30,11 @@ EXPOSE 8080
 CMD ["/env/bin/python", "main.py"]
 ```
 
+Notice `rm -rf /var/cache/apk/*` at the end of the `apk add` command. This is good practice to cleanup when you're done using `apk add` to use as little disk space as possible. After all, that's why you're using Alpine here, right?
+
 ## Virtual Packages
 
-Another great `apk add` feature for cleanup is the concept of virtual packages using the `--virtual` or `-t` switch. Packages added under this virtual name can then be removed as one group. An example use of this would be removing a group of build dependencies all at once:
+A great `apk add` feature for cleanup is the concept of virtual packages using the `--virtual` or `-t` switch. Packages added under this virtual name can then be removed as one group. An example use of this would be removing a group of build dependencies all at once:
 
 ```
 FROM gliderlabs/alpine:3.1


### PR DESCRIPTION
Proposal to deprecate `apk-install` now that there is an official alpine Docker image that does not include this helper script. Dropping `apk-install` will encourage more consistent usage of the canonical method of installing packages. It minimizes the differences between official and Glider Labs images, which is good for (new) users and good for maintainers. 

This also puts pressure on a more proper solution to removing the cache, such as adding a `--no-cache` option to `apk add` upstream, as opposed to maintaining a minimal script in a non-official image.