### PR TITLE
Bumping for 3.1.3 and security backports

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Unknown package 'nodejs'.
 Collected errors:
 * opkg_install_cmd: Cannot install package nodejs.
 
-$ docker run gliderlabs/alpine apk-install nodejs
+$ docker run gliderlabs/alpine apk --update add nodejs
 fetch http://dl-4.alpinelinux.org/alpine/v3.1/main/x86_64/APKINDEX.tar.gz
 (1/5) Installing c-ares (1.10.0-r1)
 (2/5) Installing libgcc (4.8.3-r0)
@@ -53,7 +53,7 @@ This took 19 seconds to build and yields a 164 MB image. Eww. Start doing this:
 
 ```
 FROM gliderlabs/alpine:3.1
-RUN apk-install mysql-client
+RUN apk --update add mysql-client
 ENTRYPOINT ["mysql"]
 ```
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -1,0 +1,27 @@
+# Caveats
+
+The musl libc implementation may work a little different than you are used to. The [musl libc differences from glibc document](http://wiki.musl-libc.org/wiki/Functional_differences_from_glibc#Name_Resolver_.2F_DNS) does a really good job of outlining everything. Please take a glance at it. Here we'll talk about some of the more common things you might encounter.
+
+## DNS
+
+One common issue you may find is with DNS. musl libc does not use `domain` or `search` directives in the `/etc/resolv.conf` file. For example, if you started your Docker daemon with `--dns-search=service.consul`, and then tried to resolve `consul` from within an Alpine Linux container, it would fail as the name `consul.service.consul` would not be tried. You will need to work around this by using fully qualified names.
+
+Another difference is parallel querying of name servers. This can be problematic if your first name server has a different DNS view (such as service discovery through DNS). For example, if you started your Docker daemon with `--dns=172.17.42.1 --dns=10.0.2.15` where `172.17.42.1` is a local DNS server to resolve name for service discovery and `10.0.2.15` is for external DNS resolving, you wouldn't be able to guarantee that `172.17.42.1` will always be queried first. There will be sporadic failures.
+
+In both of these cases, it can help to run a local caching DNS server such as dnsmasq, that can be used for both caching and search path routing. Running dnsmasq with `--server /consul/10.0.0.1` would forward queries for the `.consul` to 10.0.0.1.
+
+## Incompatible Binaries
+
+While there are binaries that will run on musl libc without needing to be recompiled, you will likely encounter binaries and applications that rely on specific glibc functionality that will fail to start up. An example of this would be Oracle Java which relies on specific symbols only found in glibc. You can often use `ldd` to determine the exact symbol:
+
+```console
+# ldd bin/java
+    /lib64/ld-linux-x86-64.so.2 (0x7f542ebb5000)
+    libpthread.so.0 => /lib64/ld-linux-x86-64.so.2 (0x7f542ebb5000)
+    libjli.so => bin/../lib/amd64/jli/libjli.so (0x7f542e9a0000)
+    libdl.so.2 => /lib64/ld-linux-x86-64.so.2 (0x7f542ebb5000)
+    libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7f542ebb5000)
+Error relocating bin/../lib/amd64/jli/libjli.so: __rawmemchr: symbol not found
+```
+
+In this case, the upstream would need to remove the support for this offending symbol or have the ability to compile the software natively on musl libc. Be sure to check the [Alpine Linux package index](http://forum.alpinelinux.org/packages) to see if a suitable replacement package already exists.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,10 @@ Docker images today are big. Usually much larger than they need to be. There are
 
 You use the `apk` command to manage packages. We don't ship the image with a package index (since that can go stale fairly quickly), so you need to add the `--update` flag to `apk` when installing. An example installing the `nginx` package would be `apk add --update nginx`. Check out [the usage page][usage] for more advanced usage and `Dockerfile` examples.
 
+## Caveats
+
+The musl libc implementation may work a little different than you are used to. One example of this is with DNS. musl libc does not use `domain` or `search` in the `/etc/resolv.conf` file. It also queries name servers in parallel which can be problematic if your first name server has a different DNS view (such as service discovery through DNS). We have [a page dedicated to the caveats][caveats] you should be aware of.
+
 ## Build
 
 This image is built and tested in a continuous integration environment using the `build` script. We then push the resulting images directly to Docker Hub. Check out [the page on building and testing][build] the images for more information.
@@ -31,6 +35,7 @@ We welcome contributions to the image build process, version bumps, and other op
 [about]: /docker-alpine/about
 [usage]: /docker-alpine/usage
 [build]: /docker-alpine/build
+[caveats]: /docker-alpine/caveats
 [irc]: https://kiwiirc.com/client/irc.freenode.net/#gliderlabs
 [issues]: https://github.com/gliderlabs/docker-alpine/issues
 [alpine]: http://alpinelinux.org/

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,8 +53,8 @@ FROM gliderlabs/alpine:3.1
 WORKDIR /myapp
 COPY . /myapp
 
-RUN apk-install python py-pip openssl ca-certificates
-RUN apk-install --virtual build-dependencies python-dev build-base wget \
+RUN apk --update add python py-pip openssl ca-certificates
+RUN apk --update add --virtual build-dependencies python-dev build-base wget \
   && pip install -r requirements.txt \
   && python setup.py install \
   && apk del build-dependencies

--- a/test/test_alpine-3.1.bats
+++ b/test/test_alpine-3.1.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run "alpine:3.1" cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.1.2" ]
+  [ "${lines[2]}" = "VERSION_ID=3.1.3" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_gliderlabs_alpine-3.1.bats
+++ b/test/test_gliderlabs_alpine-3.1.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run gliderlabs/alpine:3.1 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.1.2" ]
+  [ "${lines[2]}" = "VERSION_ID=3.1.3" ]
 }
 
 @test "package installs cleanly" {


### PR DESCRIPTION
This is just a merge of current master that bumps tests for 3.1.3. There were some security back ports from edge for musl and openssl.