### PR TITLE
Package-customised images and alpine-core variant images

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -12,3 +12,4 @@ The builder takes several options:
 * `-c`: Adds the `apk-install` script to the resulting rootfs.
 * `-e`: Adds extra `edge/main` and `edge/testing` pins to the repositories file.
 * `-t <timzone>`: Set the timezone. Default is `UTC`.
+* `-p <packages>`: Comma-separated packages list (`tzdata` is always installed). Default is `alpine-base`.

--- a/versions/gliderlabs-2.6/options
+++ b/versions/gliderlabs-2.6/options
@@ -1,4 +1,5 @@
 export RELEASE="v2.6"
-export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
+export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR}"
 export TAGS="gliderlabs/alpine:2.6"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-2.6/options
+++ b/versions/gliderlabs-2.6/options
@@ -1,5 +1,6 @@
 export RELEASE="v2.6"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR}"
+export PACKAGES="alpine-baselayout,apk-tools,busybox,libc-utils,alpine-keys"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR} -p ${PACKAGES}"
 export TAGS="gliderlabs/alpine:2.6"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-2.7/options
+++ b/versions/gliderlabs-2.7/options
@@ -1,5 +1,6 @@
 export RELEASE="v2.7"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR}"
+export PACKAGES="alpine-baselayout,apk-tools,busybox,libc-utils,alpine-keys"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR} -p ${PACKAGES}"
 export TAGS="gliderlabs/alpine:2.7"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-2.7/options
+++ b/versions/gliderlabs-2.7/options
@@ -1,4 +1,5 @@
 export RELEASE="v2.7"
-export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
+export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR}"
 export TAGS="gliderlabs/alpine:2.7"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-3.1/options
+++ b/versions/gliderlabs-3.1/options
@@ -1,5 +1,6 @@
 export RELEASE="v3.1"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR}"
+export PACKAGES="alpine-baselayout,apk-tools,busybox,libc-utils,alpine-keys"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR} -p ${PACKAGES}"
 export TAGS="gliderlabs/alpine:3.1"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-3.1/options
+++ b/versions/gliderlabs-3.1/options
@@ -1,5 +1,5 @@
 export RELEASE="v3.1"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR}"
 export TAGS="gliderlabs/alpine:3.1"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-3.2/options
+++ b/versions/gliderlabs-3.2/options
@@ -1,5 +1,6 @@
 export RELEASE="v3.2"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR}"
+export PACKAGES="alpine-baselayout,apk-tools,busybox,libc-utils,alpine-keys"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR} -p ${PACKAGES}"
 export TAGS="gliderlabs/alpine:3.2 gliderlabs/alpine:latest"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-3.2/options
+++ b/versions/gliderlabs-3.2/options
@@ -1,5 +1,5 @@
 export RELEASE="v3.2"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR}"
 export TAGS="gliderlabs/alpine:3.2 gliderlabs/alpine:latest"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-edge/options
+++ b/versions/gliderlabs-edge/options
@@ -1,5 +1,5 @@
 export RELEASE="edge"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR}"
 export TAGS="gliderlabs/alpine:edge"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-edge/options
+++ b/versions/gliderlabs-edge/options
@@ -1,5 +1,6 @@
 export RELEASE="edge"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR}"
+export PACKAGES="alpine-baselayout,apk-tools,busybox,libc-utils,alpine-keys"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m ${MIRROR} -p ${PACKAGES}"
 export TAGS="gliderlabs/alpine:edge"
 export PUSH_IMAGE="true"

--- a/versions/library-2.6/options
+++ b/versions/library-2.6/options
@@ -1,4 +1,5 @@
 export RELEASE="v2.6"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR}"
+export PACKAGES="alpine-baselayout,apk-tools,busybox,libc-utils,alpine-keys"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR} -p ${PACKAGES}"
 export TAGS="alpine:2.6"

--- a/versions/library-2.6/options
+++ b/versions/library-2.6/options
@@ -1,3 +1,4 @@
 export RELEASE="v2.6"
-export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
+export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR}"
 export TAGS="alpine:2.6"

--- a/versions/library-2.7/options
+++ b/versions/library-2.7/options
@@ -1,3 +1,4 @@
 export RELEASE="v2.7"
-export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
+export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR}"
 export TAGS="alpine:2.7"

--- a/versions/library-2.7/options
+++ b/versions/library-2.7/options
@@ -1,4 +1,5 @@
 export RELEASE="v2.7"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR}"
+export PACKAGES="alpine-baselayout,apk-tools,busybox,libc-utils,alpine-keys"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR} -p ${PACKAGES}"
 export TAGS="alpine:2.7"

--- a/versions/library-3.1/options
+++ b/versions/library-3.1/options
@@ -1,4 +1,4 @@
 export RELEASE="v3.1"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR}"
 export TAGS="alpine:3.1"

--- a/versions/library-3.1/options
+++ b/versions/library-3.1/options
@@ -1,4 +1,5 @@
 export RELEASE="v3.1"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR}"
+export PACKAGES="alpine-baselayout,apk-tools,busybox,libc-utils,alpine-keys"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR} -p ${PACKAGES}"
 export TAGS="alpine:3.1"

--- a/versions/library-3.2/options
+++ b/versions/library-3.2/options
@@ -1,4 +1,4 @@
 export RELEASE="v3.2"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR}"
 export TAGS="alpine:3.2 alpine:latest"

--- a/versions/library-3.2/options
+++ b/versions/library-3.2/options
@@ -1,4 +1,5 @@
 export RELEASE="v3.2"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR}"
+export PACKAGES="alpine-baselayout,apk-tools,busybox,libc-utils,alpine-keys"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR} -p ${PACKAGES}"
 export TAGS="alpine:3.2 alpine:latest"

--- a/versions/library-edge/options
+++ b/versions/library-edge/options
@@ -1,4 +1,4 @@
 export RELEASE="edge"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR}"
 export TAGS="alpine:edge"

--- a/versions/library-edge/options
+++ b/versions/library-edge/options
@@ -1,4 +1,5 @@
 export RELEASE="edge"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR}"
+export PACKAGES="alpine-baselayout,apk-tools,busybox,libc-utils,alpine-keys"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m ${MIRROR} -p ${PACKAGES}"
 export TAGS="alpine:edge"


### PR DESCRIPTION
I implemented support for build package-customised images, prepared alpine-core variant images (without init system, provided by `openrc` and `busybox-initscripts` packages) and updated edge to 3.2 RC2 version with all image variants.