### PR TITLE
Bump for 3.1.4 and 3.2.0

### DIFF
--- a/build
+++ b/build
@@ -62,17 +62,16 @@ commit() {
 
 test() {
 	declare build_files="${*:-$OPTIONS}"
+	declare -a test_files
 	for file in $build_files; do
 		source "$file"
 		local tag
 		tag="$(echo "$TAGS" | cut -d' ' -f1)"
 		tag="${tag//:/-}"
 		tag="${tag//\//_}"
-		bats "test/test_${tag}.bats"
-		# if docker history "${tag}" >/dev/null 2>&1; then
-		# 	tests/util/test "${tag//}"
-		# fi
+		test_files+=("test/test_${tag}.bats")
 	done
+	bats "${test_files[@]}"
 }
 
 main() {

--- a/test/test_alpine-3.1.bats
+++ b/test/test_alpine-3.1.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run "alpine:3.1" cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.1.3" ]
+  [ "${lines[2]}" = "VERSION_ID=3.1.4" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_alpine-3.2.bats
+++ b/test/test_alpine-3.2.bats
@@ -1,0 +1,37 @@
+setup() {
+  docker history "alpine:3.2" >/dev/null 2>&1
+}
+
+@test "version is correct" {
+  run docker run "alpine:3.2" cat /etc/os-release
+  [ $status -eq 0 ]
+  [ "${lines[2]}" = "VERSION_ID=3.2.0" ]
+}
+
+@test "package installs cleanly" {
+  run docker run "alpine:3.2" apk add --update openssl
+  [ $status -eq 0 ]
+}
+
+@test "timezone" {
+  run docker run "alpine:3.2" date +%Z
+  [ $status -eq 0 ]
+  [ "$output" = "UTC" ]
+}
+
+@test "apk-install script should be missing" {
+  run docker run "alpine:3.2" which apk-install
+  [ $status -eq 1 ]
+}
+
+@test "repository list is correct" {
+  run docker run "alpine:3.2" cat /etc/apk/repositories
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/v3.2/main" ]
+}
+
+@test "cache is empty" {
+  run docker run "alpine:3.2" sh -c "ls -1 /var/cache/apk | wc -l"
+  [ $status -eq 0 ]
+  [ "$output" = "0" ]
+}

--- a/test/test_alpine-edge.bats
+++ b/test/test_alpine-edge.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run "alpine:edge" cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.2.0_alpha1" ]
+  [ "${lines[2]}" = "VERSION_ID=3.2.0_rc2" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_alpine-edge.bats
+++ b/test/test_alpine-edge.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run "alpine:edge" cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.2.0_rc2" ]
+  [ "${lines[2]}" = "VERSION_ID=3.2.0" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_gliderlabs_alpine-3.1.bats
+++ b/test/test_gliderlabs_alpine-3.1.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run gliderlabs/alpine:3.1 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.1.3" ]
+  [ "${lines[2]}" = "VERSION_ID=3.1.4" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_gliderlabs_alpine-3.2.bats
+++ b/test/test_gliderlabs_alpine-3.2.bats
@@ -1,0 +1,37 @@
+setup() {
+  docker history gliderlabs/alpine:3.2 >/dev/null 2>&1
+}
+
+@test "version is correct" {
+  run docker run gliderlabs/alpine:3.2 cat /etc/os-release
+  [ $status -eq 0 ]
+  [ "${lines[2]}" = "VERSION_ID=3.2.0" ]
+}
+
+@test "package installs cleanly" {
+  run docker run gliderlabs/alpine:3.2 apk add --update openssl
+  [ $status -eq 0 ]
+}
+
+@test "timezone" {
+  run docker run gliderlabs/alpine:3.2 date +%Z
+  [ $status -eq 0 ]
+  [ "$output" = "UTC" ]
+}
+
+@test "apk-install script should be available" {
+  run docker run gliderlabs/alpine:3.2 which apk-install
+  [ $status -eq 0 ]
+}
+
+@test "repository list is correct" {
+  run docker run gliderlabs/alpine:3.2 cat /etc/apk/repositories
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/v3.2/main" ]
+}
+
+@test "cache is empty" {
+  run docker run gliderlabs/alpine:3.2 sh -c "ls -1 /var/cache/apk | wc -l"
+  [ $status -eq 0 ]
+  [ "$output" = "0" ]
+}

--- a/test/test_gliderlabs_alpine-edge.bats
+++ b/test/test_gliderlabs_alpine-edge.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run gliderlabs/alpine:edge cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.2.0_rc2" ]
+  [ "${lines[2]}" = "VERSION_ID=3.2.0" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_gliderlabs_alpine-edge.bats
+++ b/test/test_gliderlabs_alpine-edge.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run gliderlabs/alpine:edge cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.2.0_alpha1" ]
+  [ "${lines[2]}" = "VERSION_ID=3.2.0_rc2" ]
 }
 
 @test "package installs cleanly" {

--- a/versions/gliderlabs-3.1/options
+++ b/versions/gliderlabs-3.1/options
@@ -1,4 +1,4 @@
 export RELEASE="v3.1"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
 export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
-export TAGS="gliderlabs/alpine:3.1 gliderlabs/alpine:latest"
+export TAGS="gliderlabs/alpine:3.1"

--- a/versions/gliderlabs-3.2/Dockerfile
+++ b/versions/gliderlabs-3.2/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+ADD rootfs.tar.gz /

--- a/versions/gliderlabs-3.2/options
+++ b/versions/gliderlabs-3.2/options
@@ -1,0 +1,4 @@
+export RELEASE="v3.2"
+export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
+export TAGS="gliderlabs/alpine:3.2"

--- a/versions/gliderlabs-3.2/options
+++ b/versions/gliderlabs-3.2/options
@@ -1,4 +1,4 @@
 export RELEASE="v3.2"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
 export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
-export TAGS="gliderlabs/alpine:3.2"
+export TAGS="gliderlabs/alpine:3.2 gliderlabs/alpine:latest"

--- a/versions/library-3.1/options
+++ b/versions/library-3.1/options
@@ -1,4 +1,4 @@
 export RELEASE="v3.1"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
 export BUILD_OPTIONS="-s -t UTC -r $RELEASE -m $MIRROR"
-export TAGS="alpine:3.1 alpine:latest"
+export TAGS="alpine:3.1"

--- a/versions/library-3.2/Dockerfile
+++ b/versions/library-3.2/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+ADD rootfs.tar.gz /

--- a/versions/library-3.2/options
+++ b/versions/library-3.2/options
@@ -1,0 +1,4 @@
+export RELEASE="v3.2"
+export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -t UTC -r $RELEASE -m $MIRROR"
+export TAGS="alpine:3.2"

--- a/versions/library-3.2/options
+++ b/versions/library-3.2/options
@@ -1,4 +1,4 @@
 export RELEASE="v3.2"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
 export BUILD_OPTIONS="-s -t UTC -r $RELEASE -m $MIRROR"
-export TAGS="alpine:3.2"
+export TAGS="alpine:3.2 alpine:latest"


### PR DESCRIPTION
Most notable her is some minor fixes for properly handling mirror failures in `apk-tools`. Packages `alpine-conf` and `alpine-base` updated as well. Updated tests for latest version in stable and edge.