### PR TITLE
Switch to dl-3 mirror to gain etag and cache headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Collected errors:
 * opkg_install_cmd: Cannot install package nodejs.
 
 $ docker run gliderlabs/alpine apk --update add nodejs
-fetch http://dl-4.alpinelinux.org/alpine/v3.1/main/x86_64/APKINDEX.tar.gz
+fetch http://dl-3.alpinelinux.org/alpine/v3.1/main/x86_64/APKINDEX.tar.gz
 (1/5) Installing c-ares (1.10.0-r1)
 (2/5) Installing libgcc (4.8.3-r0)
 (3/5) Installing libstdc++ (4.8.3-r0)

--- a/test/test_alpine-2.6.bats
+++ b/test/test_alpine-2.6.bats
@@ -27,7 +27,7 @@ setup() {
 @test "repository list is correct" {
   run docker run alpine:2.6 cat /etc/apk/repositories
   [ $status -eq 0 ]
-  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/v2.6/main" ]
+  [ "${lines[0]}" = "http://dl-3.alpinelinux.org/alpine/v2.6/main" ]
 }
 
 @test "cache is empty" {

--- a/test/test_alpine-2.7.bats
+++ b/test/test_alpine-2.7.bats
@@ -27,7 +27,7 @@ setup() {
 @test "repository list is correct" {
   run docker run alpine:2.7 cat /etc/apk/repositories
   [ $status -eq 0 ]
-  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/v2.7/main" ]
+  [ "${lines[0]}" = "http://dl-3.alpinelinux.org/alpine/v2.7/main" ]
 }
 
 @test "cache is empty" {

--- a/test/test_alpine-3.1.bats
+++ b/test/test_alpine-3.1.bats
@@ -27,7 +27,7 @@ setup() {
 @test "repository list is correct" {
   run docker run "alpine:3.1" cat /etc/apk/repositories
   [ $status -eq 0 ]
-  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/v3.1/main" ]
+  [ "${lines[0]}" = "http://dl-3.alpinelinux.org/alpine/v3.1/main" ]
 }
 
 @test "cache is empty" {

--- a/test/test_alpine-3.2.bats
+++ b/test/test_alpine-3.2.bats
@@ -27,7 +27,7 @@ setup() {
 @test "repository list is correct" {
   run docker run "alpine:3.2" cat /etc/apk/repositories
   [ $status -eq 0 ]
-  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/v3.2/main" ]
+  [ "${lines[0]}" = "http://dl-3.alpinelinux.org/alpine/v3.2/main" ]
 }
 
 @test "cache is empty" {

--- a/test/test_alpine-edge.bats
+++ b/test/test_alpine-edge.bats
@@ -27,7 +27,7 @@ setup() {
 @test "repository list is correct" {
   run docker run "alpine:edge" cat /etc/apk/repositories
   [ $status -eq 0 ]
-  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/edge/main" ]
+  [ "${lines[0]}" = "http://dl-3.alpinelinux.org/alpine/edge/main" ]
 }
 
 @test "cache is empty" {

--- a/test/test_gliderlabs_alpine-2.6.bats
+++ b/test/test_gliderlabs_alpine-2.6.bats
@@ -27,7 +27,7 @@ setup() {
 @test "repository list is correct" {
   run docker run gliderlabs/alpine:2.6 cat /etc/apk/repositories
   [ $status -eq 0 ]
-  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/v2.6/main" ]
+  [ "${lines[0]}" = "http://dl-3.alpinelinux.org/alpine/v2.6/main" ]
 }
 
 @test "cache is empty" {

--- a/test/test_gliderlabs_alpine-2.7.bats
+++ b/test/test_gliderlabs_alpine-2.7.bats
@@ -27,7 +27,7 @@ setup() {
 @test "repository list is correct" {
   run docker run gliderlabs/alpine:2.7 cat /etc/apk/repositories
   [ $status -eq 0 ]
-  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/v2.7/main" ]
+  [ "${lines[0]}" = "http://dl-3.alpinelinux.org/alpine/v2.7/main" ]
 }
 
 @test "cache is empty" {

--- a/test/test_gliderlabs_alpine-3.1.bats
+++ b/test/test_gliderlabs_alpine-3.1.bats
@@ -27,7 +27,7 @@ setup() {
 @test "repository list is correct" {
   run docker run gliderlabs/alpine:3.1 cat /etc/apk/repositories
   [ $status -eq 0 ]
-  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/v3.1/main" ]
+  [ "${lines[0]}" = "http://dl-3.alpinelinux.org/alpine/v3.1/main" ]
 }
 
 @test "cache is empty" {

--- a/test/test_gliderlabs_alpine-3.2.bats
+++ b/test/test_gliderlabs_alpine-3.2.bats
@@ -27,7 +27,7 @@ setup() {
 @test "repository list is correct" {
   run docker run gliderlabs/alpine:3.2 cat /etc/apk/repositories
   [ $status -eq 0 ]
-  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/v3.2/main" ]
+  [ "${lines[0]}" = "http://dl-3.alpinelinux.org/alpine/v3.2/main" ]
 }
 
 @test "cache is empty" {

--- a/test/test_gliderlabs_alpine-edge.bats
+++ b/test/test_gliderlabs_alpine-edge.bats
@@ -27,7 +27,7 @@ setup() {
 @test "repository list is correct" {
   run docker run gliderlabs/alpine:edge cat /etc/apk/repositories
   [ $status -eq 0 ]
-  [ "${lines[0]}" = "http://dl-4.alpinelinux.org/alpine/edge/main" ]
+  [ "${lines[0]}" = "http://dl-3.alpinelinux.org/alpine/edge/main" ]
 }
 
 @test "cache is empty" {

--- a/versions/gliderlabs-2.6/options
+++ b/versions/gliderlabs-2.6/options
@@ -1,4 +1,4 @@
 export RELEASE="v2.6"
-export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m http://dl-3.alpinelinux.org/alpine"
 export TAGS="gliderlabs/alpine:2.6"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-2.7/options
+++ b/versions/gliderlabs-2.7/options
@@ -1,4 +1,4 @@
 export RELEASE="v2.7"
-export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -c -t UTC -r ${RELEASE} -m http://dl-3.alpinelinux.org/alpine"
 export TAGS="gliderlabs/alpine:2.7"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-3.1/options
+++ b/versions/gliderlabs-3.1/options
@@ -1,5 +1,5 @@
 export RELEASE="v3.1"
-export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export MIRROR="http://dl-3.alpinelinux.org/alpine"
 export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="gliderlabs/alpine:3.1"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-3.2/options
+++ b/versions/gliderlabs-3.2/options
@@ -1,5 +1,5 @@
 export RELEASE="v3.2"
-export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export MIRROR="http://dl-3.alpinelinux.org/alpine"
 export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="gliderlabs/alpine:3.2 gliderlabs/alpine:latest"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-edge/options
+++ b/versions/gliderlabs-edge/options
@@ -1,5 +1,5 @@
 export RELEASE="edge"
-export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export MIRROR="http://dl-3.alpinelinux.org/alpine"
 export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="gliderlabs/alpine:edge"
 export PUSH_IMAGE="true"

--- a/versions/library-2.6/options
+++ b/versions/library-2.6/options
@@ -1,3 +1,3 @@
 export RELEASE="v2.6"
-export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m http://dl-3.alpinelinux.org/alpine"
 export TAGS="alpine:2.6"

--- a/versions/library-2.7/options
+++ b/versions/library-2.7/options
@@ -1,3 +1,3 @@
 export RELEASE="v2.7"
-export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m http://dl-3.alpinelinux.org/alpine"
 export TAGS="alpine:2.7"

--- a/versions/library-3.1/options
+++ b/versions/library-3.1/options
@@ -1,4 +1,4 @@
 export RELEASE="v3.1"
-export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export MIRROR="http://dl-3.alpinelinux.org/alpine"
 export BUILD_OPTIONS="-s -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="alpine:3.1"

--- a/versions/library-3.2/options
+++ b/versions/library-3.2/options
@@ -1,4 +1,4 @@
 export RELEASE="v3.2"
-export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export MIRROR="http://dl-3.alpinelinux.org/alpine"
 export BUILD_OPTIONS="-s -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="alpine:3.2 alpine:latest"

--- a/versions/library-edge/options
+++ b/versions/library-edge/options
@@ -1,4 +1,4 @@
 export RELEASE="edge"
-export MIRROR="http://dl-4.alpinelinux.org/alpine"
+export MIRROR="http://dl-3.alpinelinux.org/alpine"
 export BUILD_OPTIONS="-s -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="alpine:edge"


### PR DESCRIPTION
The `dl-4` mirror doesn't have any cache-control or etag headers. This is related to and should close #46. Leaving as a pull request for feedback since it has potential side affects for using the package manager.