### PR TITLE
Bumping release for Alpine 3.2.3 and security backports

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ The code in this repository, unless otherwise noted, is BSD licensed. See the `L
 [irc]: https://kiwiirc.com/client/irc.freenode.net/#gliderlabs
 [issues]: https://github.com/gliderlabs/docker-alpine/issues
 [alpine]: http://alpinelinux.org/
+<img src="https://ga-beacon.appspot.com/UA-58928488-2/docker-alpine/readme?pixel" />

--- a/build
+++ b/build
@@ -84,6 +84,21 @@ push() {
 	done
 }
 
+library() {
+	local refs="$(git ls-remote --heads origin)"
+	echo "# maintainer: Glider Labs <team@gliderlabs.com> (@gliderlabs)"
+	for file in versions/library-*/options; do
+		source "$file"
+		local version="${RELEASE#v}"
+		echo
+		for tag in $TAGS; do
+			local tag="$(echo "$tag" | cut -d: -f2)"
+			read sha _ <<< $(echo "$refs" | grep rootfs-library-$version)
+			echo "$tag:" "git://github.com/gliderlabs/docker-alpine@$sha" "versions/library-$version"
+		done
+	done
+}
+
 main() {
 	set -eo pipefail; [[ "$TRACE" ]] && set -x
 	declare cmd="$1"
@@ -91,6 +106,7 @@ main() {
 		test)	shift;	run_tests "$@";;
 		commit)	shift;	commit "$@";;
 		push)	shift;	push "$@";;
+		library) shift; library;;
 		*)		build "$@";;
 	esac
 }

--- a/docs/build.md
+++ b/docs/build.md
@@ -6,12 +6,26 @@ A convenience `build` script is included that builds the image and runs basic te
 
 ## Image
 
+### Builder
+
 The image is built using a builder Docker container based on the `debian` image. This builder image lives in the `builder` sub-directory of the project and uses a `mkimage-alpine.sh` script to generate a Alpine Linux `rootfs.tar.gz` file. This file then gets copied to the root of the project so we can build the main Alpine Linux image by just using the `ADD` command to automatically untar the components to the resulting image.
 
-The build script takes a glob of `tags` files as an argument. Each of these files lives in a folder that describes the version of Alpine Linux to build in the parent directory name and each line of the file are the tags that will be applied to the resulting image. By default, we use the included glob of `versions/**/tags`.
+### Options
+
+The build script takes a glob of `options` files as an argument. Each of these files lives in a folder that describes the version of Alpine Linux to build. Each line of the `options` file are the options that will be applied to the resulting image. By default, we use the included glob of `versions/**/options`.
+
+### Official
+
+As we maintain the [official Alpine Linux image in the Docker Library][library], we have specific `options` files for library versions. These contain options that may differ slightly from the `gliderlabs/alpine` image. Compare the `BUILD_OPTIONS` variable to see differences between versions.
+
+In the future, Glider Labs may add features that are not available in upstream Alpine Linux (such as a package repository or scripts to install packages from GitHub). These options would not make it to the official Docker library since they are not available upstream.
+
+This should help with your image decision. If features of the `gliderlabs/alpine` image are not of importance to you and you value closest to upstream, then stick with `alpine`. If you want to use additional features we add to the image, then you would use `gliderlabs/alpine`.
 
 ## Test
 
 The test for images is very simple at the moment. It just attempts to install the `openssl` package and verify we exit cleanly.
 
 Use the `test` sub-command of the `build` utility to run tests on currently build images (`build test`).
+
+[library]: https://github.com/docker-library/official-images/blob/master/library/alpine

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,10 @@ Welcome to the documentation for the Alpine Linux Docker Image. Here we explain 
 
 The heart of this image is [Alpine Linux][alpine]. The image is only 5 MB and has access to a package repository that is much more complete than other minimal base images. Learn more [about this image][about], musl libc, BusyBox, and why the Docker Alpine Linux image makes a great base for your Docker projects.
 
+## Official
+
+This image serves as the source for the [official Alpine Linux image in the Docker Library][library]. The build process for both official `alpine` and `gliderlabs/alpine` are the same. However, different build options are used for the official library images. Check out [the build page][build] for more information on differences.
+
 ## Motivations
 
 Docker images today are big. Usually much larger than they need to be. There are a lot of ways to make them smaller. But you need to start with a small base. There are great size savings to be had when compared to base images such as `ubuntu`, `centos`, and `debian`.
@@ -39,3 +43,4 @@ We welcome contributions to the image build process, version bumps, and other op
 [irc]: https://kiwiirc.com/client/irc.freenode.net/#gliderlabs
 [issues]: https://github.com/gliderlabs/docker-alpine/issues
 [alpine]: http://alpinelinux.org/
+[library]: https://github.com/docker-library/official-images/blob/master/library/alpine

--- a/test/test_alpine-3.2.bats
+++ b/test/test_alpine-3.2.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run "alpine:3.2" cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.2.0" ]
+  [ "${lines[2]}" = "VERSION_ID=3.2.3" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_gliderlabs_alpine-3.2.bats
+++ b/test/test_gliderlabs_alpine-3.2.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run gliderlabs/alpine:3.2 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.2.0" ]
+  [ "${lines[2]}" = "VERSION_ID=3.2.3" ]
 }
 
 @test "package installs cleanly" {


### PR DESCRIPTION
Bumping for security fixes and Alpine 3.2.3. Will pair with a new pull request for official images. Should close #50.