### PR TITLE
munge `uname -m` output so that we get "armhf"

### DIFF
--- a/builder/scripts/mkimage-alpine.bash
+++ b/builder/scripts/mkimage-alpine.bash
@@ -27,9 +27,14 @@ output_redirect() {
 	fi
 }
 
+get-arch() {
+	local hwname="$(uname -m)"
+	echo "${hwname/#arm*/armhf}"
+}
+
 get-apk-version() {
 	declare release="$1" mirror="${2:-$MIRROR}"
-	local arch="$(uname -m)"
+	local arch="$(get-arch)"
 	curl -sSL "${mirror}/${release}/main/${arch}/APKINDEX.tar.gz" \
 		| tar -Oxz \
 		| grep '^P:apk-tools-static$' -a -A1 \
@@ -40,7 +45,7 @@ get-apk-version() {
 build(){
 	declare mirror="$1" rel="$2" timezone="${3:-UTC}"
 	local repo="$mirror/$rel/main"
-	local arch="$(uname -m)"
+	local arch="$(get-arch)"
 
 	# tmp
 	local tmp="$(mktemp -d "${TMPDIR:-/var/tmp}/alpine-docker-XXXXXXXXXX")"


### PR DESCRIPTION
This is honestly kind of a kludge, but I needed something along the lines of this to get the image-builder working on a Scaleway arm machine (`uname -m` reported `armv7l`, which isn't the same thing as `armhf`).