### PR TITLE
Self-hosted builder (squashed)

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.2
 COPY scripts/mkimage-alpine.bash scripts/apk-install /
-RUN /apk-install bash
+RUN /apk-install bash tzdata
 ENTRYPOINT ["/mkimage-alpine.bash"]

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
-RUN apt-get update && apt-get install -y curl wget tar
+FROM alpine:3.2
 COPY scripts/mkimage-alpine.bash scripts/apk-install /
+RUN /apk-install bash
 ENTRYPOINT ["/mkimage-alpine.bash"]

--- a/builder/README.md
+++ b/builder/README.md
@@ -11,4 +11,6 @@ The builder takes several options:
 * `-s`: Outputs the `rootfs.tar.gz` to stdout.
 * `-c`: Adds the `apk-install` script to the resulting rootfs.
 * `-e`: Adds extra `edge/main` and `edge/testing` pins to the repositories file.
-* `-t <timzone>`: Set the timezone. Default is `UTC`.
+* `-t <timezone>`: Set the timezone. Default is `UTC`.
+* `-p <packages>`: Comma-separated packages list (`tzdata` is always installed). Default is `alpine-base`. 
+* `-b`: Extracts `alpine-base` to the rootfs without dependencies. For images slimmed down with `-p` which still want `/etc/*-release` and `/etc/issue`.

--- a/builder/README.md
+++ b/builder/README.md
@@ -12,5 +12,5 @@ The builder takes several options:
 * `-c`: Adds the `apk-install` script to the resulting rootfs.
 * `-e`: Adds extra `edge/main` and `edge/testing` pins to the repositories file.
 * `-t <timezone>`: Set the timezone. Default is `UTC`.
-* `-p <packages>`: Comma-separated packages list (`tzdata` is always installed). Default is `alpine-base`. 
+* `-p <packages>`: Comma-separated packages list (`tzdata` is always installed). Default is `alpine-base`.
 * `-b`: Extracts `alpine-base` to the rootfs without dependencies. For images slimmed down with `-p` which still want `/etc/*-release` and `/etc/issue`.

--- a/builder/scripts/mkimage-alpine.bash
+++ b/builder/scripts/mkimage-alpine.bash
@@ -50,10 +50,8 @@ build() {
 		apk --update-cache fetch --recursive --output "$tmp" ${packages//,/ }
 		[[ "$ADD_BASELAYOUT" ]] && \
 			apk fetch --stdout alpine-base | tar -xvz -C "$rootfs" etc
-		[[ "$TIMEZONE" ]] && {
-			apk add tzdata
-			install -Dm 644 "/usr/share/zoneinfo/$TIMEZONE" "$rootfs/etc/localtime"
-		}
+		[[ "$TIMEZONE" ]] && install -Dm 644 \
+			"/usr/share/zoneinfo/$TIMEZONE" "$rootfs/etc/localtime"
 		apk --root "$rootfs" --allow-untrusted add --initdb "$tmp"/*.apk
 		install -Dm 644 /etc/apk/repositories "$rootfs/etc/apk/repositories"
 	} | output_redirect

--- a/builder/scripts/mkimage-alpine.bash
+++ b/builder/scripts/mkimage-alpine.bash
@@ -27,16 +27,6 @@ output_redirect() {
 	fi
 }
 
-get-apk-version() {
-	declare release="$1" mirror="${2:-$MIRROR}"
-	local arch="$(uname -m)"
-	curl -sSL "${mirror}/${release}/main/${arch}/APKINDEX.tar.gz" \
-		| tar -Oxz \
-		| grep '^P:apk-tools-static$' -a -A1 \
-		| tail -n1 \
-		| cut -d: -f2
-}
-
 build(){
 	declare mirror="$1" rel="$2" timezone="${3:-UTC}"
 	local repo="$mirror/$rel/main"
@@ -47,33 +37,23 @@ build(){
 	local rootfs="$(mktemp -d "${TMPDIR:-/var/tmp}/alpine-docker-rootfs-XXXXXXXXXX")"
 	# trap "rm -rf $tmp $rootfs" EXIT TERM INT
 
-	# get apk
-	curl -sSL "${repo}/${arch}/apk-tools-static-$(get-apk-version "$rel").apk" \
-		| tar -xz -C "$tmp" sbin/apk.static \
-		| output_redirect
-
 	# mkbase
-	"${tmp}/sbin/apk.static" \
-		--repository "$repo" \
-		--root "$rootfs" \
-		--update-cache \
-		--allow-untrusted \
-		--initdb \
-			add alpine-base tzdata | output_redirect
-	cp -a "${rootfs}/usr/share/zoneinfo/${timezone}" "${rootfs}/etc/localtime"
-	"${tmp}/sbin/apk.static" \
-		--root "$rootfs" \
-			del tzdata | output_redirect
-	rm -f "${rootfs}"/var/cache/apk/* | output_redirect
+	{
+		apk --repository "$repo" --update-cache \
+			fetch --recursive --output "$tmp" alpine-base tzdata
+		apk --root "$rootfs" --allow-untrusted add --initdb "$tmp"/*.apk
+		cp -a "$rootfs/usr/share/zoneinfo/$timezone" "$rootfs/etc/localtime"
+		apk --root "$rootfs" del tzdata
+	} | output_redirect
 
 	# conf
-	printf '%s\n' "$repo" > "${rootfs}/etc/apk/repositories"
+	printf '%s\n' "$repo" > "$rootfs/etc/apk/repositories"
 	[[ "$REPO_EXTRA" ]] && {
-		[[ "$rel" == "edge" ]] || printf '%s\n' "@edge ${mirror}/edge/main" >> "${rootfs}/etc/apk/repositories"
-		printf '%s\n' "@testing ${mirror}/edge/testing" >> "${rootfs}/etc/apk/repositories"
+		[[ "$rel" == "edge" ]] || printf '%s\n' "@edge $mirror/edge/main" >> "$rootfs/etc/apk/repositories"
+		printf '%s\n' "@testing $mirror/edge/testing" >> "$rootfs/etc/apk/repositories"
 	}
 
-	[[ "$ADD_APK_SCRIPT" ]] && cp /apk-install "${rootfs}/usr/sbin/apk-install"
+	[[ "$ADD_APK_SCRIPT" ]] && cp /apk-install "$rootfs/usr/sbin/apk-install"
 
 	# save
 	tar -z -f rootfs.tar.gz --numeric-owner -C "$rootfs" -c .


### PR DESCRIPTION
I squashed this down to five commits, corresponding to three "features":

- self-hosting
- package customization
- optional tzdata

in principle 2cc718a is a bugfix for 907dbc6 and 0d2fa44 is a bugfix for 38b6171; however, the intervening commits created context changes which makes reordering nontrivial, so I just left extra commits instead of risking manual mismerging.

The code is identical to my selfhosted-history branch except for the removal of a trailing space in builder/README.md.