### PR TITLE
symmetry + doc fix

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -11,6 +11,6 @@ The builder takes several options:
 * `-s`: Outputs the `rootfs.tar.gz` to stdout.
 * `-c`: Adds the `apk-install` script to the resulting rootfs.
 * `-e`: Adds extra `edge/main` and `edge/testing` pins to the repositories file.
-* `-t <timezone>`: Set the timezone. Default is `UTC`.
-* `-p <packages>`: Comma-separated packages list (`tzdata` is always installed). Default is `alpine-base`.
+* `-t <timezone>`: Sets the timezone.
+* `-p <packages>`: Comma-separated packages list. Default is `alpine-base`.
 * `-b`: Extracts `alpine-base` to the rootfs without dependencies. For images slimmed down with `-p` which still want `/etc/*-release` and `/etc/issue`.

--- a/builder/scripts/mkimage-alpine.bash
+++ b/builder/scripts/mkimage-alpine.bash
@@ -18,14 +18,6 @@ usage() {
 	printf >&2 '%s: [-r release] [-m mirror] [-s] [-e] [-c] [-t timezone] [-p packages] [-b]\n' "$0" && exit 1
 }
 
-output_redirect() {
-	if [[ "$STDOUT" ]]; then
-		cat - 1>&2
-	else
-		cat -
-	fi
-}
-
 build() {
 	declare mirror="$1" rel="$2" packages="${3:-alpine-base}"
 	local repo="$mirror/$rel/main"
@@ -54,7 +46,7 @@ build() {
 			"/usr/share/zoneinfo/$TIMEZONE" "$rootfs/etc/localtime"
 		apk --root "$rootfs" --allow-untrusted add --initdb "$tmp"/*.apk
 		install -Dm 644 /etc/apk/repositories "$rootfs/etc/apk/repositories"
-	} | output_redirect
+	} >&2
 
 	[[ "$ADD_APK_SCRIPT" ]] && cp /apk-install "$rootfs/usr/sbin/apk-install"
 

--- a/builder/scripts/mkimage-alpine.bash
+++ b/builder/scripts/mkimage-alpine.bash
@@ -21,7 +21,6 @@ usage() {
 build() {
 	declare mirror="$1" rel="$2" packages="${3:-alpine-base}"
 	local repo="$mirror/$rel/main"
-	local arch="$(uname -m)"
 
 	# tmp
 	local tmp="$(mktemp -d "${TMPDIR:-/var/tmp}/alpine-docker-XXXXXXXXXX")"
@@ -61,7 +60,7 @@ main() {
 	while getopts "hr:m:t:secp:b" opt; do
 		case $opt in
 			r) REL="$OPTARG";;
-			m) MIRROR="$OPTARG";;
+			m) MIRROR="${OPTARG%/}";;
 			s) STDOUT=1;;
 			e) REPO_EXTRA=1;;
 			t) TIMEZONE="$OPTARG";;


### PR DESCRIPTION
ab86f87 makes the apk output all go on stderr, because it didn't seem justifiable to have the output_redirect logic. was there ever any use for putting it on stdout? it's not like we have anything else go on stderr?

3b6c341 is a pure docfix, tzdata hasn't been mandatory since 38b6171.