### PR TITLE
Add community repo

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -11,6 +11,7 @@ The builder takes several options:
 * `-s`: Outputs the `rootfs.tar.gz` to stdout.
 * `-c`: Adds the `apk-install` script to the resulting rootfs.
 * `-e`: Adds extra `edge/main` and `edge/testing` pins to the repositories file.
+* `-E`: Does not add `community` to the repositories file (necessary for versions without a community repo).
 * `-t <timezone>`: Sets the timezone.
 * `-p <packages>`: Comma-separated packages list. Default is `alpine-base`.
 * `-b`: Extracts `alpine-base` to the rootfs without dependencies. For images slimmed down with `-p` which still want `/etc/*-release` and `/etc/issue`.

--- a/builder/README.md
+++ b/builder/README.md
@@ -11,6 +11,6 @@ The builder takes several options:
 * `-s`: Outputs the `rootfs.tar.gz` to stdout.
 * `-c`: Adds the `apk-install` script to the resulting rootfs.
 * `-e`: Adds extra `edge/main` and `edge/testing` pins to the repositories file.
-* `-t <timezone>`: Set the timezone. Default is `UTC`.
-* `-p <packages>`: Comma-separated packages list (`tzdata` is always installed). Default is `alpine-base`.
+* `-t <timezone>`: Sets the timezone.
+* `-p <packages>`: Comma-separated packages list. Default is `alpine-base`.
 * `-b`: Extracts `alpine-base` to the rootfs without dependencies. For images slimmed down with `-p` which still want `/etc/*-release` and `/etc/issue`.

--- a/builder/scripts/mkimage-alpine.bash
+++ b/builder/scripts/mkimage-alpine.bash
@@ -15,12 +15,11 @@ set -eo pipefail; [[ "$TRACE" ]] && set -x
 }
 
 usage() {
-	printf >&2 '%s: [-r release] [-m mirror] [-s] [-e] [-c] [-t timezone] [-p packages] [-b]\n' "$0" && exit 1
+	printf >&2 '%s: [-r release] [-m mirror] [-s] [-E] [-e] [-c] [-t timezone] [-p packages] [-b]\n' "$0" && exit 1
 }
 
 build() {
 	declare mirror="$1" rel="$2" packages="${3:-alpine-base}"
-	local repo="$mirror/$rel/main"
 
 	# tmp
 	local tmp="$(mktemp -d "${TMPDIR:-/var/tmp}/alpine-docker-XXXXXXXXXX")"
@@ -29,7 +28,8 @@ build() {
 
 	# conf
 	{
-		echo "$repo"
+    echo "$mirror/$rel/main"
+    [[ "$OMIT_COMMUNITY" ]] || echo "$mirror/$rel/community"
 		[[ "$REPO_EXTRA" ]] && {
 			[[ "$rel" == "edge" ]] || echo "@edge $mirror/edge/main"
 			echo "@testing $mirror/edge/testing"
@@ -57,11 +57,12 @@ build() {
 }
 
 main() {
-	while getopts "hr:m:t:secp:b" opt; do
+	while getopts "hr:m:t:sEecp:b" opt; do
 		case $opt in
 			r) REL="$OPTARG";;
 			m) MIRROR="${OPTARG%/}";;
 			s) STDOUT=1;;
+			E) OMIT_COMMUNITY=1;;
 			e) REPO_EXTRA=1;;
 			t) TIMEZONE="$OPTARG";;
 			c) ADD_APK_SCRIPT=1;;

--- a/builder/scripts/mkimage-alpine.bash
+++ b/builder/scripts/mkimage-alpine.bash
@@ -18,14 +18,6 @@ usage() {
 	printf >&2 '%s: [-r release] [-m mirror] [-s] [-e] [-c] [-t timezone] [-p packages] [-b]\n' "$0" && exit 1
 }
 
-output_redirect() {
-	if [[ "$STDOUT" ]]; then
-		cat - 1>&2
-	else
-		cat -
-	fi
-}
-
 build() {
 	declare mirror="$1" rel="$2" packages="${3:-alpine-base}"
 	local repo="$mirror/$rel/main"
@@ -54,7 +46,7 @@ build() {
 			"/usr/share/zoneinfo/$TIMEZONE" "$rootfs/etc/localtime"
 		apk --root "$rootfs" --allow-untrusted add --initdb "$tmp"/*.apk
 		install -Dm 644 /etc/apk/repositories "$rootfs/etc/apk/repositories"
-	} | output_redirect
+	} >&2
 
 	[[ "$ADD_APK_SCRIPT" ]] && cp /apk-install "$rootfs/usr/sbin/apk-install"
 

--- a/builder/scripts/mkimage-alpine.bash
+++ b/builder/scripts/mkimage-alpine.bash
@@ -21,7 +21,6 @@ usage() {
 build() {
 	declare mirror="$1" rel="$2" packages="${3:-alpine-base}"
 	local repo="$mirror/$rel/main"
-	local arch="$(uname -m)"
 
 	# tmp
 	local tmp="$(mktemp -d "${TMPDIR:-/var/tmp}/alpine-docker-XXXXXXXXXX")"
@@ -61,7 +60,7 @@ main() {
 	while getopts "hr:m:t:secp:b" opt; do
 		case $opt in
 			r) REL="$OPTARG";;
-			m) MIRROR="$OPTARG";;
+			m) MIRROR="${OPTARG%/}";;
 			s) STDOUT=1;;
 			e) REPO_EXTRA=1;;
 			t) TIMEZONE="$OPTARG";;

--- a/versions/gliderlabs-2.6/options
+++ b/versions/gliderlabs-2.6/options
@@ -1,5 +1,5 @@
 export RELEASE="v2.6"
 export MIRROR="http://alpine.gliderlabs.com/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -E -c -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="gliderlabs/alpine:2.6"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-2.7/options
+++ b/versions/gliderlabs-2.7/options
@@ -1,5 +1,5 @@
 export RELEASE="v2.7"
 export MIRROR="http://alpine.gliderlabs.com/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -E -c -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="gliderlabs/alpine:2.7"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-3.1/options
+++ b/versions/gliderlabs-3.1/options
@@ -1,5 +1,5 @@
 export RELEASE="v3.1"
 export MIRROR="http://alpine.gliderlabs.com/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -E -c -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="gliderlabs/alpine:3.1"
 export PUSH_IMAGE="true"

--- a/versions/gliderlabs-3.2/options
+++ b/versions/gliderlabs-3.2/options
@@ -1,5 +1,5 @@
 export RELEASE="v3.2"
 export MIRROR="http://alpine.gliderlabs.com/alpine"
-export BUILD_OPTIONS="-s -c -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -E -c -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="gliderlabs/alpine:3.2 gliderlabs/alpine:latest"
 export PUSH_IMAGE="true"

--- a/versions/library-2.6/options
+++ b/versions/library-2.6/options
@@ -1,3 +1,3 @@
 export RELEASE="v2.6"
-export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -E -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
 export TAGS="alpine:2.6"

--- a/versions/library-2.7/options
+++ b/versions/library-2.7/options
@@ -1,3 +1,3 @@
 export RELEASE="v2.7"
-export BUILD_OPTIONS="-s -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
+export BUILD_OPTIONS="-s -E -t UTC -r ${RELEASE} -m http://dl-4.alpinelinux.org/alpine"
 export TAGS="alpine:2.7"

--- a/versions/library-3.1/options
+++ b/versions/library-3.1/options
@@ -1,4 +1,4 @@
 export RELEASE="v3.1"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -E -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="alpine:3.1"

--- a/versions/library-3.2/options
+++ b/versions/library-3.2/options
@@ -1,4 +1,4 @@
 export RELEASE="v3.2"
 export MIRROR="http://dl-4.alpinelinux.org/alpine"
-export BUILD_OPTIONS="-s -t UTC -r $RELEASE -m $MIRROR"
+export BUILD_OPTIONS="-s -E -t UTC -r $RELEASE -m $MIRROR"
 export TAGS="alpine:3.2 alpine:latest"


### PR DESCRIPTION
The community repo is a recent development for packages which will be available by default but without extended support.

I've chosen to implement it as default, with a switch to turn it *off* on grounds that in the future all useful versions *will* have a community repo and won't complain about it.

This supersedes #87 mainly because it would otherwise have a bunch of merge conflict.