### PR TITLE
avoid the fetch + --allow-untrusted dance by specifying --keys-dir

### DIFF
--- a/builder/scripts/mkimage-alpine.bash
+++ b/builder/scripts/mkimage-alpine.bash
@@ -28,8 +28,8 @@ build() {
 
 	# conf
 	{
-    echo "$mirror/$rel/main"
-    [[ "$OMIT_COMMUNITY" ]] || echo "$mirror/$rel/community"
+		echo "$mirror/$rel/main"
+		[[ "$OMIT_COMMUNITY" ]] || echo "$mirror/$rel/community"
 		[[ "$REPO_EXTRA" ]] && {
 			[[ "$rel" == "edge" ]] || echo "@edge $mirror/edge/main"
 			echo "@testing $mirror/edge/testing"


### PR DESCRIPTION
so I learned today in irc that if --keys-dir is specified apk will take its keys from *outside* the chroot, which means there's no need to prefetch.