### PR TITLE
Add "CMD"

### DIFF
--- a/versions/gliderlabs-3.1/Dockerfile
+++ b/versions/gliderlabs-3.1/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 ADD rootfs.tar.gz /
+CMD ["/bin/sh"]

--- a/versions/gliderlabs-3.2/Dockerfile
+++ b/versions/gliderlabs-3.2/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 ADD rootfs.tar.gz /
+CMD ["/bin/sh"]

--- a/versions/gliderlabs-3.3/Dockerfile
+++ b/versions/gliderlabs-3.3/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 ADD rootfs.tar.gz /
+CMD ["/bin/sh"]

--- a/versions/gliderlabs-3.4/Dockerfile
+++ b/versions/gliderlabs-3.4/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 ADD rootfs.tar.gz /
+CMD ["/bin/sh"]

--- a/versions/gliderlabs-edge/Dockerfile
+++ b/versions/gliderlabs-edge/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 ADD rootfs.tar.gz /
+CMD ["/bin/sh"]

--- a/versions/library-3.1/Dockerfile
+++ b/versions/library-3.1/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 ADD rootfs.tar.gz /
+CMD ["/bin/sh"]

--- a/versions/library-3.2/Dockerfile
+++ b/versions/library-3.2/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 ADD rootfs.tar.gz /
+CMD ["/bin/sh"]

--- a/versions/library-3.3/Dockerfile
+++ b/versions/library-3.3/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 ADD rootfs.tar.gz /
+CMD ["/bin/sh"]

--- a/versions/library-3.4/Dockerfile
+++ b/versions/library-3.4/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 ADD rootfs.tar.gz /
+CMD ["/bin/sh"]

--- a/versions/library-3.5/Dockerfile
+++ b/versions/library-3.5/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 ADD rootfs.tar.gz /
+CMD ["/bin/sh"]

--- a/versions/library-edge/Dockerfile
+++ b/versions/library-edge/Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
 ADD rootfs.tar.gz /
+CMD ["/bin/sh"]


### PR DESCRIPTION
This was rejected previously (#60) on the basis of keeping the layer count to an absolute minimum.  Since Docker 1.10+, instructions like "CMD" simply modify metadata and no longer create an additional layer that needs to be transported at pull time.  I'm hoping that means we can reconsider it?  :innocent:

Closes #193
