### PR TITLE
Correct py-pip to be py2-pip in documentation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,7 @@ FROM gliderlabs/alpine:3.3
 RUN apk add --update \
     python \
     python-dev \
-    py-pip \
+    py2-pip \
     build-base \
   && pip install virtualenv \
   && rm -rf /var/cache/apk/*


### PR DESCRIPTION
The existing example using py-pip will resolve in 'ERROR: unsatisfiable constraints'.

See issue https://github.com/docker/docker-birthday-3/issues/118.