### PR TITLE
Adds an optional ARCH flag to the build script.

### DIFF
--- a/build
+++ b/build
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -vx
 
 build() {
 	declare build_files="${*:-versions/**/options}"

--- a/build
+++ b/build
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
+set -vx
 
 build() {
 	declare build_files="${*:-versions/**/options}"
 
-	[[ "$BUILDER_IMAGE" ]] || {
-		BUILDER_IMAGE="alpine-builder"
-		docker build -t "$BUILDER_IMAGE" builder
-	}
-
 	for file in $build_files; do
 		( # shellcheck source=versions/gliderlabs-3.2/options
+        unset RELEASE ARCH MIRROR PACKAGES BUILDER_IMAGE BUILD_OPTIONS TAGS
 		source "$file"
 		local version_dir
 		version_dir="$(dirname "$file")"
-		: "${TAGS:?}" "${BUILD_OPTIONS:?}" "${RELEASE:?}"
+		: "${TAGS:?}" "${BUILD_OPTIONS:?}" "${RELEASE:?}" "${ARCH:-x86}"
+        ARCH=${ARCH:-x86}
+        [[ "$BUILDER_IMAGE" ]] || BUILDER_IMAGE="alpine-builder-${ARCH}"
+        [[ "$(docker images $BUILDER_IMAGE -q) 2> /dev/null)" == "" ]] || {
+            BUILDER_IMAGE="alpine-builder-${ARCH}"
+            docker build -t "$BUILDER_IMAGE" builder -f "builder/Dockerfile-${ARCH}"
+        }
 		docker run -e "TRACE=$TRACE" --rm "$BUILDER_IMAGE" "${BUILD_OPTIONS[@]}" \
 			> "$version_dir/rootfs.tar.gz"
 

--- a/builder/Dockerfile-aarch64
+++ b/builder/Dockerfile-aarch64
@@ -1,0 +1,4 @@
+FROM owlab/alpine-arm64
+COPY scripts/mkimage-alpine.bash scripts/apk-install /
+RUN /apk-install bash tzdata
+ENTRYPOINT ["/mkimage-alpine.bash"]

--- a/builder/Dockerfile-armhf
+++ b/builder/Dockerfile-armhf
@@ -1,0 +1,4 @@
+FROM hypriot/rpi-alpine-scratch:v3.2
+COPY scripts/mkimage-alpine.bash scripts/apk-install /
+RUN /apk-install bash tzdata
+ENTRYPOINT ["/mkimage-alpine.bash"]

--- a/builder/Dockerfile-x86
+++ b/builder/Dockerfile-x86
@@ -1,0 +1,4 @@
+FROM alpine:3.2
+COPY scripts/mkimage-alpine.bash scripts/apk-install /
+RUN /apk-install bash tzdata
+ENTRYPOINT ["/mkimage-alpine.bash"]

--- a/versions/aarch64-3.5/Dockerfile
+++ b/versions/aarch64-3.5/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+ADD rootfs.tar.gz /

--- a/versions/aarch64-3.5/options
+++ b/versions/aarch64-3.5/options
@@ -1,5 +1,5 @@
 export RELEASE="v3.5"
-export ARCH="armhf"
+export ARCH="aarch64"
 export MIRROR="http://dl-cdn.alpinelinux.org/alpine"
 export PACKAGES="alpine-baselayout,alpine-keys,apk-tools,libc-utils"
 export BUILDER_IMAGE="alpine-builder-${ARCH}"

--- a/versions/arm-3.5/Dockerfile
+++ b/versions/arm-3.5/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+ADD rootfs.tar.gz /

--- a/versions/arm-3.5/options
+++ b/versions/arm-3.5/options
@@ -1,0 +1,7 @@
+export RELEASE="v3.5"
+export ARCH="armhf"
+export MIRROR="http://dl-cdn.alpinelinux.org/alpine"
+export PACKAGES="alpine-baselayout,alpine-keys,apk-tools,libc-utils"
+export BUILDER_IMAGE="alpine-builder-armhf"
+export BUILD_OPTIONS=(-b -s -t UTC -r $RELEASE -m $MIRROR -p $PACKAGES)
+export TAGS=(alpine-$ARCH:3.5 alpine-$ARCH:latest)


### PR DESCRIPTION
Howdy,

So, I made a few changes to the build script to support specifying an optional ARCH flag which would be read in from the options file. This enables building of arm images as in #237 as well as other architectures.