### PR TITLE
Fix "./build library"

### DIFF
--- a/build
+++ b/build
@@ -114,10 +114,7 @@ push() {
 	done
 }
 
-# TODO: make this work...
 library() {
-	declare options_files="${*:-versions/library-*/**/options}" # does this need globstar?
-
 	convert() {
 		# takes a space-separated list of alpine-linux architectures, and returns a space-separated list of docker architectures
 		local i=0
@@ -129,7 +126,7 @@ library() {
 				aarch64) echo -n "arm64v8";;
 				ppc64le) echo -n "ppc64le";;
 				s390x) echo -n "s390x";;
-				*) return 1;; # Fail on unknown archs
+				*) echo >&2 "error: unknown arch '$arch'"; return 1;; # Fail on unknown archs
 			esac
 			if [[ i -ne $#-1 ]]; then
 				echo -n " "
@@ -144,18 +141,24 @@ library() {
 	echo "Maintainers: Glider Labs <team@gliderlabs.com> (@gliderlabs)"
 	echo "GitRepo: https://github.com/gliderlabs/docker-alpine.git"
 
-	for file in versions/library-*/options; do
+	for file in versions/library-*/x86_64/options versions/library-*/options; do
 		# shellcheck source=versions/library-3.2/options
 		source "$file"
 		local refs version_dir release
-		version_dir="${file%/*}"
-		release="${version_dir##versions/}"
+		version_dir="${file%/options}"
+		version_dir="${version_dir%/x86_64}"
+		release="${version_dir#versions/}"
 		refs="$(git ls-remote --exit-code --heads origin rootfs/${release})"
 		: "${refs:?}"
 		tags="${TAGS[*]}"
-		[[ "${ARCHS[*]}" ]] || { # compatability with older configs that were only written for x86_64 architectures
-				ARCHS=("x86_64")
-		}
+		if [ -e "$version_dir/options" ]; then
+			# compatability with older configs that were only written for x86_64 architectures
+			ARCHS=("x86_64")
+		else
+			ARCHS=( "$version_dir"/*/options )
+			ARCHS=( "${ARCHS[@]#$version_dir/}" )
+			ARCHS=( "${ARCHS[@]%/*}" )
+		fi
 		a="$(convert "${ARCHS[@]}")"
 
 		echo
@@ -168,7 +171,12 @@ library() {
 		for arch in $a; do
 			# ${ARCHS[i]} is the alpine version string, different from $archs, the docker version string.
 			# Our folder structure is based on the alpine version string
-			echo "$arch-Directory: versions/library-${RELEASE#v}/${ARCHS[i]}"
+			if [ -e "$version_dir/options" ]; then
+				# compatability with older configs that were only written for x86_64 architectures
+				echo "$arch-Directory: $version_dir"
+			else
+				echo "$arch-Directory: $version_dir/${ARCHS[i]}"
+			fi
 			let i=i+1
 		done
 	done


### PR DESCRIPTION
Follow-up for https://github.com/gliderlabs/docker-alpine/pull/352.

Example output:

```console
$ ./build library

# autogenerated by https://github.com/gliderlabs/docker-alpine/blob/master/build

Maintainers: Glider Labs <team@gliderlabs.com> (@gliderlabs)
GitRepo: https://github.com/gliderlabs/docker-alpine.git

Tags: alpine:3.6, alpine:latest
Architectures: arm64v8, arm32v6, ppc64le, s390x, amd64, i386
GitFetch: refs/heads/rootfs/library-3.6
GitCommit: 1df7cd436b81e0c8f6f84beb3bf8031de21829d4
arm64v8-Directory: versions/library-3.6/aarch64
arm32v6-Directory: versions/library-3.6/armhf
ppc64le-Directory: versions/library-3.6/ppc64le
s390x-Directory: versions/library-3.6/s390x
amd64-Directory: versions/library-3.6/x86_64
i386-Directory: versions/library-3.6/x86

Tags: alpine:edge
Architectures: arm64v8, arm32v6, ppc64le, s390x, amd64, i386
GitFetch: refs/heads/rootfs/library-edge
GitCommit: c0f432b0e678c1096e041e7e63a089444ad544c9
arm64v8-Directory: versions/library-edge/aarch64
arm32v6-Directory: versions/library-edge/armhf
ppc64le-Directory: versions/library-edge/ppc64le
s390x-Directory: versions/library-edge/s390x
amd64-Directory: versions/library-edge/x86_64
i386-Directory: versions/library-edge/x86

Tags: alpine:3.1
Architectures: amd64
GitFetch: refs/heads/rootfs/library-3.1
GitCommit: 42d89fb9844b17e50875b97c631dd1ca1591107c
amd64-Directory: versions/library-3.1

Tags: alpine:3.2
Architectures: amd64
GitFetch: refs/heads/rootfs/library-3.2
GitCommit: f78fe34e562a3cd50501a44d41a4384a90d9dd42
amd64-Directory: versions/library-3.2

Tags: alpine:3.3
Architectures: amd64
GitFetch: refs/heads/rootfs/library-3.3
GitCommit: 003bfad270dd87ce9cba3b2782a39229c61932f5
amd64-Directory: versions/library-3.3

Tags: alpine:3.4
Architectures: amd64
GitFetch: refs/heads/rootfs/library-3.4
GitCommit: 9fd08ce7d9040ab265adca36633f09570176a4fa
amd64-Directory: versions/library-3.4

Tags: alpine:3.5
Architectures: amd64
GitFetch: refs/heads/rootfs/library-3.5
GitCommit: 731d755ebe08c13be6df34d2ea2daaacbfc974b0
amd64-Directory: versions/library-3.5

```