### PR TITLE
Reverse to version 3.7 for latest tag

### DIFF
--- a/versions/library-3.7/x86_64/options
+++ b/versions/library-3.7/x86_64/options
@@ -2,4 +2,4 @@ export RELEASE="v3.7"
 export MIRROR="http://dl-cdn.alpinelinux.org/alpine"
 export PACKAGES="alpine-baselayout,busybox,alpine-keys,apk-tools,libc-utils"
 export BUILD_OPTIONS=(-b -s -t UTC -r $RELEASE -m $MIRROR -p $PACKAGES)
-export TAGS=(alpine:3.7)
+export TAGS=(alpine:3.7 alpine:latest)

--- a/versions/library-3.8/x86_64/options
+++ b/versions/library-3.8/x86_64/options
@@ -2,4 +2,4 @@ export RELEASE="v3.8"
 export MIRROR="http://dl-cdn.alpinelinux.org/alpine"
 export PACKAGES="alpine-baselayout,busybox,alpine-keys,apk-tools,libc-utils"
 export BUILD_OPTIONS=(-b -s -t UTC -r $RELEASE -m $MIRROR -p $PACKAGES)
-export TAGS=(alpine:3.8 alpine:latest)
+export TAGS=(alpine:3.8)


### PR DESCRIPTION
This pull request is related to #418 issue.

I think first of all todo things is rust to reverse to version 3.7 for latest tag.