### PR TITLE
docs/index.md: remove ambiguous text

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ We welcome contributions to the image build process, version bumps, and other op
 
 [![Fastly](https://github.com/gliderlabs/docker-alpine/raw/master/logo_fastly.png)][fastly]
 
-[Fastly][fastly] provides the CDN for our Alpine Linux package repository. This allows super speedy package downloads from all over the globe! Check out
+[Fastly][fastly] provides the CDN for our Alpine Linux package repository. This allows super speedy package downloads from all over the globe!
 
 [about]: /docker-alpine/about
 [usage]: /docker-alpine/usage


### PR DESCRIPTION
Closes #482. 

Removes ambiguous text from the docs' `Sponsors` Section.