### PR TITLE
Default to using https mirror

### DIFF
--- a/builder/scripts/mkimage-alpine.bash
+++ b/builder/scripts/mkimage-alpine.bash
@@ -6,7 +6,7 @@
 # Luis Lavena (luislavena).
 
 declare REL="${REL:-edge}"
-declare MIRROR="${MIRROR:-http://nl.alpinelinux.org/alpine}"
+declare MIRROR="${MIRROR:-https://nl.alpinelinux.org/alpine}"
 
 set -eo pipefail; [[ "$TRACE" ]] && set -x
 


### PR DESCRIPTION
No idea if this would have would have unintended side-effects. But I saw that the url accepts https so I thought I'd propose using https.

Just a random drive-by pull request from someone who pretty much doesn't use docker at all. Feel free to close if it's a bad idea.