### PR TITLE
Bump alpine 3.9.0 to 3.9.2

### DIFF
--- a/test/test_alpine-3.9.bats
+++ b/test/test_alpine-3.9.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run alpine:3.9 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.9.0" ]
+  [ "${lines[2]}" = "VERSION_ID=3.9.2" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_gliderlabs_alpine-3.9.bats
+++ b/test/test_gliderlabs_alpine-3.9.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run gliderlabs/alpine:3.9 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.9.0" ]
+  [ "${lines[2]}" = "VERSION_ID=3.9.2" ]
 }
 
 @test "package installs cleanly" {

--- a/versions/library-3.9/aarch64/options
+++ b/versions/library-3.9/aarch64/options
@@ -1,4 +1,4 @@
-version=3.9.0
+version=3.9.2
 export ARCH="aarch64"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/armhf/options
+++ b/versions/library-3.9/armhf/options
@@ -1,4 +1,4 @@
-version=3.9.0
+version=3.9.2
 export ARCH="armhf"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/ppc64le/options
+++ b/versions/library-3.9/ppc64le/options
@@ -1,4 +1,4 @@
-version=3.9.0
+version=3.9.2
 export ARCH="ppc64le"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/s390x/options
+++ b/versions/library-3.9/s390x/options
@@ -1,4 +1,4 @@
-version=3.9.0
+version=3.9.2
 export ARCH="s390x"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/x86/options
+++ b/versions/library-3.9/x86/options
@@ -1,4 +1,4 @@
-version=3.9.0
+version=3.9.2
 export ARCH="x86"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})


### PR DESCRIPTION
Fixes #495 

[Alpine 3.9.2](https://alpinelinux.org/posts/Alpine-3.9.2-released.html) was released today (3/4/19). I looked at some previous commits that did a similar version bump, but I wasn't sure if this is all that needed to be done (or if we need to wait for something else) or if there is more necessary.