### PR TITLE
Version bump 3.9.1 and 3.9.2

### DIFF
--- a/versions/library-3.9/aarch64/options
+++ b/versions/library-3.9/aarch64/options
@@ -1,4 +1,4 @@
-version=3.9.1
+version=3.9.2
 export ARCH="aarch64"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/aarch64/options
+++ b/versions/library-3.9/aarch64/options
@@ -1,4 +1,4 @@
-version=3.9.0
+version=3.9.1
 export ARCH="aarch64"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/armhf/options
+++ b/versions/library-3.9/armhf/options
@@ -1,4 +1,4 @@
-version=3.9.1
+version=3.9.2
 export ARCH="armhf"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/armhf/options
+++ b/versions/library-3.9/armhf/options
@@ -1,4 +1,4 @@
-version=3.9.0
+version=3.9.1
 export ARCH="armhf"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/ppc64le/options
+++ b/versions/library-3.9/ppc64le/options
@@ -1,4 +1,4 @@
-version=3.9.1
+version=3.9.2
 export ARCH="ppc64le"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/ppc64le/options
+++ b/versions/library-3.9/ppc64le/options
@@ -1,4 +1,4 @@
-version=3.9.0
+version=3.9.1
 export ARCH="ppc64le"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/s390x/options
+++ b/versions/library-3.9/s390x/options
@@ -1,4 +1,4 @@
-version=3.9.0
+version=3.9.1
 export ARCH="s390x"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/s390x/options
+++ b/versions/library-3.9/s390x/options
@@ -1,4 +1,4 @@
-version=3.9.1
+version=3.9.2
 export ARCH="s390x"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/x86/options
+++ b/versions/library-3.9/x86/options
@@ -1,4 +1,4 @@
-version=3.9.1
+version=3.9.2
 export ARCH="x86"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})

--- a/versions/library-3.9/x86/options
+++ b/versions/library-3.9/x86/options
@@ -1,4 +1,4 @@
-version=3.9.0
+version=3.9.1
 export ARCH="x86"
 export PULL_URL="http://dl-cdn.alpinelinux.org/alpine/v${version%.*}/releases/${ARCH}/alpine-minirootfs-${version}-${ARCH}.tar.gz"
 export TAGS=(alpine:${version%.*}-${ARCH})


### PR DESCRIPTION
Not sure what the procedure here is, but 3.9 has options file still referencing 3.9.0; whereas 3.9.2 is out, so bump both version (not sure if CI needs to have both to generate both images).