### PR TITLE
fix: change `--update` flag to `--update-cache` in docs and tests

### DIFF
--- a/builder/scripts/apk-install
+++ b/builder/scripts/apk-install
@@ -1,2 +1,2 @@
 #!/bin/sh
-apk add --update "$@" && rm -rf /var/cache/apk/*
+apk add --update-cache "$@" && rm -rf /var/cache/apk/*

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Docker images today are big. Usually much larger than they need to be. There are
 
 ## Usage
 
-You use the `apk` command to manage packages. We don't ship the image with a package index (since that can go stale fairly quickly), so you need to add the `--update` flag to `apk` when installing. An example installing the `nginx` package would be `apk add --update nginx`. Check out [the usage page][usage] for more advanced usage and `Dockerfile` examples.
+You use the `apk` command to manage packages. We don't ship the image with a package index (since that can go stale fairly quickly), so you need to add the `--update-cache` flag to `apk` when installing. An example installing the `nginx` package would be `apk add --update-cache nginx`. Check out [the usage page][usage] for more advanced usage and `Dockerfile` examples.
 
 ## Caveats
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,7 +4,7 @@
 
 Replacing your current base image with the Docker Alpine Linux image usually requires updating the package names to the corresponding ones in the [Alpine Linux package index][packageindex]. We use the `apk` command to manage packages. It works similar to `apt` or `yum`.
 
-An example installing the `nginx` package would be `apk add --update nginx`. The `--update` flag fetches the current package index before adding the package. We don't ship the image with a package index (since that can go stale fairly quickly).
+An example installing the `nginx` package would be `apk add --update-cache nginx`. The `--update-cache` flag fetches the current package index before adding the package. We don't ship the image with a package index (since that can go stale fairly quickly).
 
 ## Example
 
@@ -13,7 +13,7 @@ Here is a full example `Dockerfile` that installs the Python runtime and some bu
 ```
 FROM gliderlabs/alpine:3.3
 
-RUN apk add --update \
+RUN apk add --update-cache \
     python \
     python-dev \
     py-pip \
@@ -43,7 +43,7 @@ EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
 ```
 
-This avoids the need to use `--update` and remove `/var/cache/apk/*` when done installing packages.
+This avoids the need to use `--update-cache` and remove `/var/cache/apk/*` when done installing packages.
 
 ## Convenience Cleanup
 
@@ -59,8 +59,8 @@ FROM gliderlabs/alpine:3.3
 WORKDIR /myapp
 COPY . /myapp
 
-RUN apk --update add python py-pip openssl ca-certificates
-RUN apk --update add --virtual build-dependencies python-dev build-base wget \
+RUN apk --update-cache add python py-pip openssl ca-certificates
+RUN apk --update-cache add --virtual build-dependencies python-dev build-base wget \
   && pip install -r requirements.txt \
   && python setup.py install \
   && apk del build-dependencies

--- a/test/test_alpine-3.1.bats
+++ b/test/test_alpine-3.1.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run "alpine:3.1" apk add --update openssl
+  run docker run "alpine:3.1" apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_alpine-3.2.bats
+++ b/test/test_alpine-3.2.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run "alpine:3.2" apk add --update openssl
+  run docker run "alpine:3.2" apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_alpine-3.3.bats
+++ b/test/test_alpine-3.3.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run alpine:3.3 apk add --update openssl
+  run docker run alpine:3.3 apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_alpine-3.4.bats
+++ b/test/test_alpine-3.4.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run alpine:3.4 apk add --update openssl
+  run docker run alpine:3.4 apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_alpine-3.6.bats
+++ b/test/test_alpine-3.6.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run alpine:3.6 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.6.3" ]
+  [ "${lines[2]}" = "VERSION_ID=3.6.5" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_alpine-3.7.bats
+++ b/test/test_alpine-3.7.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run alpine:3.7 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.7.1" ]
+  [ "${lines[2]}" = "VERSION_ID=3.7.3" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_alpine-3.8.bats
+++ b/test/test_alpine-3.8.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run alpine:3.8 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.8.2" ]
+  [ "${lines[2]}" = "VERSION_ID=3.8.5" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_alpine-3.9.bats
+++ b/test/test_alpine-3.9.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run alpine:3.9 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.9.0" ]
+  [ "${lines[2]}" = "VERSION_ID=3.9.5" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_alpine-edge.bats
+++ b/test/test_alpine-edge.bats
@@ -12,7 +12,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run "alpine:edge" apk add --update openssl
+  run docker run "alpine:edge" apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_alpine-edge.bats
+++ b/test/test_alpine-edge.bats
@@ -6,7 +6,7 @@ setup() {
   run docker run "alpine:edge" cat /etc/os-release
   [ $status -eq 0 ]
   case "${lines[2]}" in
-    VERSION_ID=3.9*) true;;
+    VERSION_ID=3.12*) true;;
     *) false;;
   esac
 }

--- a/test/test_gliderlabs_alpine-3.1.bats
+++ b/test/test_gliderlabs_alpine-3.1.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run gliderlabs/alpine:3.1 apk add --update openssl
+  run docker run gliderlabs/alpine:3.1 apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_gliderlabs_alpine-3.2.bats
+++ b/test/test_gliderlabs_alpine-3.2.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run gliderlabs/alpine:3.2 apk add --update openssl
+  run docker run gliderlabs/alpine:3.2 apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_gliderlabs_alpine-3.3.bats
+++ b/test/test_gliderlabs_alpine-3.3.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run gliderlabs/alpine:3.3 apk add --update openssl
+  run docker run gliderlabs/alpine:3.3 apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_gliderlabs_alpine-3.4.bats
+++ b/test/test_gliderlabs_alpine-3.4.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run gliderlabs/alpine:3.4 apk add --update openssl
+  run docker run gliderlabs/alpine:3.4 apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_gliderlabs_alpine-3.5.bats
+++ b/test/test_gliderlabs_alpine-3.5.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run gliderlabs/alpine:3.5 apk add --update openssl
+  run docker run gliderlabs/alpine:3.5 apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_gliderlabs_alpine-3.6.bats
+++ b/test/test_gliderlabs_alpine-3.6.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run gliderlabs/alpine:3.6 apk add --update openssl
+  run docker run gliderlabs/alpine:3.6 apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_gliderlabs_alpine-3.6.bats
+++ b/test/test_gliderlabs_alpine-3.6.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run gliderlabs/alpine:3.6 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.6.3" ]
+  [ "${lines[2]}" = "VERSION_ID=3.6.5" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_gliderlabs_alpine-3.7.bats
+++ b/test/test_gliderlabs_alpine-3.7.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run gliderlabs/alpine:3.7 apk add --update openssl
+  run docker run gliderlabs/alpine:3.7 apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_gliderlabs_alpine-3.7.bats
+++ b/test/test_gliderlabs_alpine-3.7.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run gliderlabs/alpine:3.7 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.7.1" ]
+  [ "${lines[2]}" = "VERSION_ID=3.7.3" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_gliderlabs_alpine-3.8.bats
+++ b/test/test_gliderlabs_alpine-3.8.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run gliderlabs/alpine:3.8 apk add --update openssl
+  run docker run gliderlabs/alpine:3.8 apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_gliderlabs_alpine-3.8.bats
+++ b/test/test_gliderlabs_alpine-3.8.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run gliderlabs/alpine:3.8 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.8.2" ]
+  [ "${lines[2]}" = "VERSION_ID=3.8.5" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_gliderlabs_alpine-3.9.bats
+++ b/test/test_gliderlabs_alpine-3.9.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run gliderlabs/alpine:3.9 apk add --update openssl
+  run docker run gliderlabs/alpine:3.9 apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_gliderlabs_alpine-3.9.bats
+++ b/test/test_gliderlabs_alpine-3.9.bats
@@ -5,7 +5,7 @@ setup() {
 @test "version is correct" {
   run docker run gliderlabs/alpine:3.9 cat /etc/os-release
   [ $status -eq 0 ]
-  [ "${lines[2]}" = "VERSION_ID=3.9.0" ]
+  [ "${lines[2]}" = "VERSION_ID=3.9.5" ]
 }
 
 @test "package installs cleanly" {

--- a/test/test_gliderlabs_alpine-edge.bats
+++ b/test/test_gliderlabs_alpine-edge.bats
@@ -12,7 +12,7 @@ setup() {
 }
 
 @test "package installs cleanly" {
-  run docker run gliderlabs/alpine:edge apk add --update openssl
+  run docker run gliderlabs/alpine:edge apk add --update-cache openssl
   [ $status -eq 0 ]
 }
 

--- a/test/test_gliderlabs_alpine-edge.bats
+++ b/test/test_gliderlabs_alpine-edge.bats
@@ -6,7 +6,7 @@ setup() {
   run docker run gliderlabs/alpine:edge cat /etc/os-release
   [ $status -eq 0 ]
   case "${lines[2]}" in
-    VERSION_ID=3.9*) true;;
+    VERSION_ID=3.12*) true;;
     *) false;;
   esac
 }


### PR DESCRIPTION
`apk --update` flag is really `--update-cache`.

https://github.com/alpinelinux/apk-tools/blob/v2.10.3/src/apk.c#L201

Apk uses `getopt_long (3)`,
https://github.com/alpinelinux/apk-tools/blob/v2.10.3/src/apk.c#L574

So, `--update` flag is only abbreviated from `--update-cache` by getopt_long.

```
Long option names may be abbreviated if the abbreviation is unique or
is an exact match for some defined option.
```

https://linux.die.net/man/3/getopt_long